### PR TITLE
fix: allow user-provided relative locktime for spending tx

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,7 @@ pub fn extract_xprv_from_descriptor(descriptor: &str) -> Result<String, String> 
     }
 }
 
+/// Generate n key pairs from the loaded default wallet.
 pub fn wallet_keypairs(
     bitcoind: &BitcoinD,
     secp: &Secp256k1<All>,
@@ -192,6 +193,8 @@ pub fn wallet_keypairs(
     key_pairs
 }
 
+/// Mine bitcoins to the descriptor address returning the coinbase
+/// transaction in the block at cb_block_index.
 pub fn mine_bitcoins(
     bitcoind: &BitcoinD,
     ms_descr: &Descriptor<PublicKey>,
@@ -217,6 +220,8 @@ pub fn mine_bitcoins(
     coinbase_tx.clone()
 }
 
+/// Mine bitcoins to the provided address returning the coinbase
+/// transaction in the block at cb_block_index.
 pub fn mine_bitcoins_to_address(
     bitcoind: &BitcoinD,
     address: &Address,
@@ -255,7 +260,16 @@ pub fn generate_new_checked_address(bitcoind: &BitcoinD) -> Address {
     checked_addr
 }
 
-pub fn spending_tx(dest_addr: Address, amount: Amount, lock_tx: &Transaction) -> Transaction {
+/// Creates a spending transaction given the destination address,
+/// amount to send, the transaction containing the output being spent
+///  from, and the relative timelock that emcumbers the transaction
+/// output being spent.
+pub fn spending_tx(
+    dest_addr: Address,
+    amount: Amount,
+    lock_tx: &Transaction,
+    sequence: Sequence,
+) -> Transaction {
     let output = TxOut {
         value: amount,
         script_pubkey: dest_addr.script_pubkey(),
@@ -267,7 +281,7 @@ pub fn spending_tx(dest_addr: Address, amount: Amount, lock_tx: &Transaction) ->
             vout: 0,
         },
         script_sig: ScriptBuf::new(),
-        sequence: Sequence::from_consensus(6),
+        sequence,
         witness: Witness::new(),
     };
 
@@ -315,7 +329,8 @@ pub fn generate_signature(
     }
 }
 
-pub fn create_psbt(
+/// Helper function to create a PSBT
+fn create_psbt(
     bitcoind: &BitcoinD,
     prev_outpoint: OutPoint,
     sequence: Option<u32>,

--- a/tests/stage2.rs
+++ b/tests/stage2.rs
@@ -44,7 +44,7 @@ fn test_one_key_can_spend() {
     // 5. Generate spending tx and valid signature.
     let dest_address = generate_new_checked_address(&bitcoind_inst);
     let amount = Amount::from_sat(coinbase_tx.output[0].value.to_sat() - 10_000);
-    let mut spend_tx = spending_tx(dest_address.clone(), amount, &coinbase_tx);
+    let mut spend_tx = spending_tx(dest_address.clone(), amount, &coinbase_tx, rel_timelock);
 
     let bitcoin_script = miniscript.encode();
     let ws = bitcoin_script.as_script();

--- a/tests/stage3.rs
+++ b/tests/stage3.rs
@@ -40,7 +40,7 @@ fn one_of_two_equally_likely_first() {
     // 5. Generate spending tx and valid signature.
     let dest_address = generate_new_checked_address(&bitcoind_inst);
     let amount = Amount::from_sat(coinbase_tx.output[0].value.to_sat() - 10_000);
-    let mut spend_tx = spending_tx(dest_address.clone(), amount, &coinbase_tx);
+    let mut spend_tx = spending_tx(dest_address.clone(), amount, &coinbase_tx, rel_timelock);
 
     let bitcoin_script = miniscript.encode();
     let ws = bitcoin_script.as_script();
@@ -90,7 +90,7 @@ fn one_of_two_equally_likely_second() {
     // 5. Generate spending tx and valid signature.
     let dest_address = generate_new_checked_address(&bitcoind_inst);
     let amount = Amount::from_sat(coinbase_tx.output[0].value.to_sat() * 4 / 5);
-    let mut spend_tx = spending_tx(dest_address.clone(), amount, &coinbase_tx);
+    let mut spend_tx = spending_tx(dest_address.clone(), amount, &coinbase_tx, rel_timelock);
 
     let bitcoin_script = miniscript.encode();
     let ws = bitcoin_script.as_script();

--- a/tests/stage4.rs
+++ b/tests/stage4.rs
@@ -42,7 +42,7 @@ fn one_of_two_one_unlikely() {
     // 5. Generate spending tx and valid signature.
     let dest_address = generate_new_checked_address(&bitcoind_inst);
     let amount = Amount::from_sat(coinbase_tx.output[0].value.to_sat() * 4 / 5);
-    let mut spend_tx = spending_tx(dest_address.clone(), amount, &coinbase_tx);
+    let mut spend_tx = spending_tx(dest_address.clone(), amount, &coinbase_tx, rel_timelock);
 
     let bitcoin_script = miniscript.encode();
     let ws = bitcoin_script.as_script();
@@ -101,7 +101,7 @@ fn one_of_two_one_more_likely() {
     // 5. Generate spending tx and valid signature.
     let dest_address = generate_new_checked_address(&bitcoind_inst);
     let amount = Amount::from_sat(coinbase_tx.output[0].value.to_sat() * 4 / 5);
-    let mut spend_tx = spending_tx(dest_address.clone(), amount, &coinbase_tx);
+    let mut spend_tx = spending_tx(dest_address.clone(), amount, &coinbase_tx, rel_timelock);
 
     let bitcoin_script = miniscript.encode();
     let ws = bitcoin_script.as_script();

--- a/tests/stage5.rs
+++ b/tests/stage5.rs
@@ -50,7 +50,7 @@ fn user_without_service_or_timelock() {
     // 5. Generate spending tx and valid signature.
     let dest_address = generate_new_checked_address(&bitcoind_inst);
     let amount = Amount::from_sat(coinbase_tx.output[0].value.to_sat() * 4 / 5);
-    let mut spend_tx = spending_tx(dest_address.clone(), amount, &coinbase_tx);
+    let mut spend_tx = spending_tx(dest_address.clone(), amount, &coinbase_tx, rel_timelock);
 
     let bs = miniscript.encode();
     let ws = bs.as_script();
@@ -112,7 +112,7 @@ fn user_and_service() {
     // 5. Generate spending tx and valid signature.
     let dest_address = generate_new_checked_address(&bitcoind_inst);
     let amount = Amount::from_sat(coinbase_tx.output[0].value.to_sat() * 4 / 5);
-    let mut spend_tx = spending_tx(dest_address.clone(), amount, &coinbase_tx);
+    let mut spend_tx = spending_tx(dest_address.clone(), amount, &coinbase_tx, rel_timelock);
 
     let bs = miniscript.encode();
     let ws = bs.as_script();
@@ -202,12 +202,12 @@ fn user_and_timelock() {
     let dest_address = generate_new_checked_address(&bitcoind_inst);
     let amount = Amount::from_sat(lock_tx.output[0].value.to_sat() - 10_000);
 
-    let mut spend_tx = spending_tx(dest_address.clone(), amount, &lock_tx);
+    let mut spend_tx = spending_tx(dest_address.clone(), amount, &lock_tx, rel_timelock);
 
     let bs = miniscript.encode();
     let ws = bs.as_script();
 
-    // // Task 3: Valid signature(s) generation
+    // Task 3: Valid signature(s) generation
     let signature_user = todo!(
         "generate a signature matching the user's public key encoded in the spending condition"
     );


### PR DESCRIPTION
## What this PR does:
- Allows users to provide their own relative locktime instead of the hardcoded value.
- Adds some documentation to the library functions.